### PR TITLE
possible fix for chapter 8?

### DIFF
--- a/08-lambda-the-ultimate.ss
+++ b/08-lambda-the-ultimate.ss
@@ -111,7 +111,7 @@
       (cond
         ((null? l) '())
         ((test? (car l) old)
-         (cons new (cons old (cdr l))))
+         (cons old (cons new (cdr l))))
         (else
           (cons (car l) ((insertR-f test?) new old (cdr l))))))))
 


### PR DESCRIPTION
Helle Peteris!

Thank you for putting the code for this delightful book on github! I'm going through chapter 8 (trying to learn the Y Combinator) while I noticed the definitions for insertL-f and insertR-f seem to be identical! I checked back with my paper copy and made what I think is a fix.
